### PR TITLE
Fix tcpserver for later firmware versions

### DIFF
--- a/tcpserver.js
+++ b/tcpserver.js
@@ -7,6 +7,7 @@ const EOL = "\n";
 const VERSION = "0.1.9";
 
 // Configuration - start
+const HOST = "0.0.0.0";
 const PORT = 8124;
 const EVENT_BUTTON = "button";
 // Configuration - end
@@ -122,7 +123,7 @@ net.createServer(function (socket) {
     buttons.on('buttonReady', buttonReadyHandler);
     buttons.on('buttonAdded', buttonAddedHandler);
 
-    socket.setEncoding();
+    socket.setEncoding("utf8");
 
     socket.on('end', function () {
         console.log('Client disconnected: ' + socket.remoteAddress);
@@ -159,7 +160,7 @@ net.createServer(function (socket) {
             }
         });
     });
-}).listen(PORT, function () {
+}).listen(PORT, HOST, function () {
     console.log("Opened server on port: " + PORT);
 });
 


### PR DESCRIPTION
It looks like some things have changed in the SDK in later hub firmware versions (and they don't match the documentation):

- Specifying a host is required now, even though the documentation says it's supposed to default to 0.0.0.0.
- `setEncoding()` needs to explicitly receive "utf8" as an argument.