### PR TITLE
Fix: Make task creation in twist controller thread-safe

### DIFF
--- a/pyflichub/twist_controller.py
+++ b/pyflichub/twist_controller.py
@@ -17,12 +17,18 @@ class RateDetentController:
     Handles converting raw positional values to smooth, variable-speed detent increments
     with features like sticky neutral, debounce, and speed tiers.
     """
-    def __init__(self, cfg: Optional[Dict[str, Any]] = None, on_change_callback: Optional[Callable[[Optional[int]], None]] = None):
+    def __init__(
+        self,
+        cfg: Optional[Dict[str, Any]] = None,
+        on_change_callback: Optional[Callable[[Optional[int]], None]] = None,
+        loop: Optional[asyncio.AbstractEventLoop] = None
+    ):
         if cfg is None:
             cfg = {}
 
         self.cfg = cfg
         self.on_change_callback = on_change_callback
+        self._loop = loop
 
         self.tick_ms = self.cfg.get("tickMs", 333)
 
@@ -188,7 +194,14 @@ class RateDetentController:
             return None
 
         if self._timer_task is None and self._running:
-            self._timer_task = asyncio.create_task(self._tick_loop())
+            try:
+                loop = asyncio.get_running_loop()
+                self._timer_task = loop.create_task(self._tick_loop())
+            except RuntimeError:
+                if self._loop is not None:
+                    self._timer_task = asyncio.run_coroutine_threadsafe(self._tick_loop(), self._loop)
+                else:
+                    self._timer_task = asyncio.get_event_loop().create_task(self._tick_loop())
 
         if self.actual_out_pct is None:
             self.actual_out_pct = self.min_out_pct


### PR DESCRIPTION
This PR fixes a `RuntimeError: no running event loop` issue that occurs when `update_raw()` in the `RateDetentController` is called from an integration that happens to run in a different thread or synchronous context without a running event loop.

By adding an explicit `loop` argument to the constructor and utilizing `asyncio.run_coroutine_threadsafe()`, task creation is now resilient against multi-threaded environments while still perfectly preserving original behavior if an explicit loop isn't provided.

---
*PR created automatically by Jules for task [8534114922616346351](https://jules.google.com/task/8534114922616346351) started by @JohNan*