### PR TITLE
Fix RateDetentController stepping up endlessly

### DIFF
--- a/pyflichub/twist_controller.py
+++ b/pyflichub/twist_controller.py
@@ -75,6 +75,10 @@ class RateDetentController:
         self._running = True
         self._timer_task = None
 
+        self.timeout_ms = self.cfg.get("timeoutMs", 500)
+        self._last_raw_time = time.time() * 1000
+        self._last_raw_in_pct = None
+
     def _desired_speed(self, abs_off: float) -> int:
         if abs_off <= self.tier1_max_off:
             return 1
@@ -193,6 +197,9 @@ class RateDetentController:
         if not isinstance(raw_in_pct, (int, float)):
             return None
 
+        self._last_raw_time = time.time() * 1000
+        self._last_raw_in_pct = raw_in_pct
+
         if self._timer_task is None and self._running:
             try:
                 loop = asyncio.get_running_loop()
@@ -241,6 +248,17 @@ class RateDetentController:
     def _tick(self):
         if self.actual_out_pct is None:
             return
+
+        now = time.time() * 1000
+        if self.timeout_ms and (now - self._last_raw_time) > self.timeout_ms:
+            if self.current_dir != 0 or self.current_speed != 0:
+                self.current_dir = 0
+                self.current_speed = 0
+                if self._last_raw_in_pct is not None:
+                    self.center_in_pct = self._last_raw_in_pct
+                self.neutral_latched = True
+                self.speed_latched = 0
+
         if self.current_dir == 0 or self.current_speed == 0:
             return
 


### PR DESCRIPTION
This commit fixes an issue where the `RateDetentController` for the virtual twist device would endlessly increase output after a user twisted the device right and stopped. It adds a `timeoutMs` to the configuration (defaults to 500) and resets the current speed and direction to 0 if the elapsed time since the last `update_raw` call exceeds the timeout. This allows the user to intuitively decrease the output later without needing to "unwind" past the invisible old center.

---
*PR created automatically by Jules for task [7985001014021495829](https://jules.google.com/task/7985001014021495829) started by @JohNan*