### PR TITLE
fix: increase twist sensitivity by reducing deadband

### DIFF
--- a/pyflichub/twist_controller.py
+++ b/pyflichub/twist_controller.py
@@ -33,8 +33,8 @@ class RateDetentController:
         self.tick_ms = self.cfg.get("tickMs", 333)
 
         # Neutral hysteresis
-        self.deadband_enter = self.cfg.get("deadbandEnter", 5)
-        self.deadband_exit = self.cfg.get("deadbandExit", 9)
+        self.deadband_enter = self.cfg.get("deadbandEnter", 2)
+        self.deadband_exit = self.cfg.get("deadbandExit", 5)
 
         # Speed tiers
         self.tier1_max_off = self.cfg.get("tier1MaxOff", 25)


### PR DESCRIPTION
Decreased the default `deadbandEnter` from 5 to 2 and `deadbandExit` from 9 to 5 in `pyflichub/twist_controller.py` to make the RateDetentController more sensitive to small Flic Twist movements.

---
*PR created automatically by Jules for task [3307193986667018133](https://jules.google.com/task/3307193986667018133) started by @JohNan*