### PR TITLE
feat: Add support for playing raw IR timings

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -168,4 +168,5 @@ The `FlicHubTcpClient` provides the following main methods for interacting with 
 *   `get_hubinfo() -> FlicHubInfo | None`: Retrieve the networking and general information about the Flic Hub.
 *   `async_check_for_updates()`: Checks if there is a newer version of the Python library or the Flic Hub `tcpserver.js` script.
 *   `play_ir(signal_id: str)`: Replays an infrared signal saved on the Flic Hub using the `ir` module.
+*   `play_ir_raw(arr: list[int])`: Plays a raw IR signal provided as an array of timings, starting with the carrier frequency in Hz.
 *   `send_virtual_device_update_state(dimmable_type: str, virtual_device_id: str, values: dict)`: Update the state of a virtual device (e.g., synchronizing brightness for a Flic Twist).

--- a/docs/events.md
+++ b/docs/events.md
@@ -157,6 +157,25 @@ Fired when a Flic Twist rotates to control a virtual device. Contains values in 
 }
 ```
 
+### `irResult`
+Fired after an infrared signal is requested to be played via `play_ir` or `play_ir_raw`. The action will be either `'success'` or `'failed'`. If failed, `meta_data` will contain an `'error'` message.
+```json
+{
+  "event": "irResult",
+  "action": "success"
+}
+```
+Or in case of an error:
+```json
+{
+  "event": "irResult",
+  "action": "failed",
+  "meta_data": {
+    "error": "Error: could not play IR signal"
+  }
+}
+```
+
 ## Client API
 
 The `FlicHubTcpClient` provides the following main methods for interacting with the Flic Hub:

--- a/pyflichub/client.py
+++ b/pyflichub/client.py
@@ -38,7 +38,7 @@ class FlicHubTcpClient(asyncio.Protocol):
     network: FlicHubInfo
 
     def __init__(self, ip, port, loop, timeout=1.0, reconnect_timeout=10.0, event_callback=None, command_callback=None):
-        self._data_ready: dict[str: Union[asyncio.Event, None]] = {}
+        self._data_ready: dict[str : Union[asyncio.Event, None]] = {}
         self._transport = None
         self._command_callback = command_callback
         self._event_callback = event_callback
@@ -62,8 +62,7 @@ class FlicHubTcpClient(asyncio.Protocol):
                 _LOGGER.info("Trying to connect to %s", self._server_address)
                 try:
                     await asyncio.wait_for(
-                        self._loop.create_connection(lambda: self, *self._server_address),
-                        self._reconnect_timeout
+                        self._loop.create_connection(lambda: self, *self._server_address), self._reconnect_timeout
                     )
                     self._tcp_check_timer = time.time()
                     self._tcp_disconnect_timer = time.time()
@@ -100,26 +99,37 @@ class FlicHubTcpClient(asyncio.Protocol):
         return self._async_send_command(cmd)
 
     def send_virtual_device_update_state(self, dimmable_type: str, virtual_device_id: str, values: dict):
-        payload = json.dumps({
-            "command": "virtualDeviceUpdateState",
-            "dimmableType": dimmable_type,
-            "virtualDeviceId": virtual_device_id,
-            "values": values
-        })
+        payload = json.dumps(
+            {
+                "command": "virtualDeviceUpdateState",
+                "dimmableType": dimmable_type,
+                "virtualDeviceId": virtual_device_id,
+                "values": values,
+            }
+        )
         if self._transport is not None:
             self._transport.write(f"{payload}\n".encode())
         else:
             _LOGGER.error("Connections seems to be closed.")
 
     def play_ir(self, signal_id: str):
-        payload = json.dumps({
-            "command": ServerCommand.PLAY_IR,
-            "signal_id": signal_id
-        })
+        payload = json.dumps({"command": ServerCommand.PLAY_IR, "signal_id": signal_id})
         if self._transport is not None:
             self._transport.write(f"{payload}\n".encode())
         else:
             _LOGGER.error("Connections seems to be closed.")
+
+    def play_ir_raw(self, arr: list[int]):
+        """
+        Plays a raw IR signal.
+        The first element of the array should contain a carrier frequency in Hz (usually 38000 Hz).
+        The following elements indicate in microseconds how long each pulse should be active or silent, alternating.
+        """
+        payload = json.dumps({"command": ServerCommand.PLAY_IR_RAW, "arr": arr})
+        if self._transport is not None:
+            self._transport.write(f"{payload}\n".encode())
+        else:
+            _LOGGER.error("Connection seems to be closed.")
 
     async def get_buttons(self) -> list[FlicButton]:
         command: Command = await self._async_send_command_and_wait_for_data(ServerCommand.BUTTONS)
@@ -149,9 +159,13 @@ class FlicHubTcpClient(asyncio.Protocol):
         # Check Hub version
         server_info = await self.get_server_info()
         if server_info and server_info.version:
-            update_available, latest_version = await self._loop.run_in_executor(None, check_for_updates, server_info.version)
+            update_available, latest_version = await self._loop.run_in_executor(
+                None, check_for_updates, server_info.version
+            )
             if update_available:
-                print(f"A new version of the Flic Hub script is available: {latest_version} (current: {server_info.version})")
+                print(
+                    f"A new version of the Flic Hub script is available: {latest_version} (current: {server_info.version})"
+                )
                 print(f"Please update the code in your Flic Hub: {UPDATE_LINK}")
 
     def _async_send_command(self, cmd: ServerCommand):
@@ -184,8 +198,8 @@ class FlicHubTcpClient(asyncio.Protocol):
 
     def data_received(self, data):
         self._buffer += data
-               
-        _LOGGER.debug('Data received: {!r}'.format(data.decode('utf-8', errors='replace')))
+
+        _LOGGER.debug("Data received: {!r}".format(data.decode("utf-8", errors="replace")))
 
         while b"\n" in self._buffer:
             line, self._buffer = self._buffer.split(b"\n", 1)
@@ -193,18 +207,18 @@ class FlicHubTcpClient(asyncio.Protocol):
             if not decoded_line:
                 continue
 
-            if decoded_line == 'pong':
+            if decoded_line == "pong":
                 pass
 
             try:
                 msg = json.loads(decoded_line, cls=_JSONDecoder)
-                if 'event' in msg:
+                if "event" in msg:
                     self._handle_event(Event(**msg))
-                if 'command' in msg:
+                if "command" in msg:
                     self._handle_command(Command(**msg))
             except Exception as e:
                 _LOGGER.warning(e, exc_info=True)
-                _LOGGER.warning('Unable to decode received data')
+                _LOGGER.warning("Unable to decode received data")
 
     def connection_lost(self, exc):
         _LOGGER.info("Connection lost")
@@ -230,52 +244,60 @@ class FlicHubTcpClient(asyncio.Protocol):
 
     def _handle_event(self, event: Event):
         button = None
-        if event.event == 'button':
+        if event.event == "button":
             button = self._get_button(event.button)
             if button:
                 _LOGGER.debug(f"Button {button.name} was {event.action}")
 
-        elif event.event == 'buttonAdded':
+        elif event.event == "buttonAdded":
             button = self._get_button(event.button)
             if not button:
                 _LOGGER.debug(f"Button {event.button} added, fetching details")
                 self._loop.create_task(self.get_buttons())
 
-        elif event.event == 'buttonDeleted':
+        elif event.event == "buttonDeleted":
             button = self._get_button(event.button)
             if button:
                 _LOGGER.debug(f"Button {button.name} deleted")
                 self.buttons.remove(button)
 
-        elif event.event == 'buttonConnected':
+        elif event.event == "buttonConnected":
             button = self._get_button(event.button)
             if button:
                 button.connected = True
                 _LOGGER.debug(f"Button {button.name} is connected")
 
-        elif event.event == 'buttonDisconnected':
+        elif event.event == "buttonDisconnected":
             button = self._get_button(event.button)
             if button:
                 button.connected = False
                 _LOGGER.debug(f"Button {button.name} is disconnected")
 
-        elif event.event == 'buttonReady':
+        elif event.event == "buttonReady":
             button = self._get_button(event.button)
             if button:
                 button.ready = True
                 _LOGGER.debug(f"Button {button.name} is ready")
 
-        elif event.event == 'actionMessage':
+        elif event.event == "actionMessage":
             _LOGGER.debug(f"Action message received: {event.action}")
 
-        elif event.event == 'virtualDeviceUpdate':
-            if event.meta_data and 'virtual_device_id' in event.meta_data:
+        elif event.event == "virtualDeviceUpdate":
+            if event.meta_data and "virtual_device_id" in event.meta_data:
                 _LOGGER.debug(f"Virtual device update received: {event.meta_data['virtual_device_id']}")
-            if event.meta_data and 'button_id' in event.meta_data:
-                button = self._get_button(event.meta_data['button_id'])
+            if event.meta_data and "button_id" in event.meta_data:
+                button = self._get_button(event.meta_data["button_id"])
 
         if self._event_callback is not None:
-            if event.event in ['actionMessage', 'virtualDeviceUpdate', 'buttonAdded', 'buttonDeleted', 'buttonConnected', 'buttonDisconnected', 'buttonReady']:
+            if event.event in [
+                "actionMessage",
+                "virtualDeviceUpdate",
+                "buttonAdded",
+                "buttonDeleted",
+                "buttonConnected",
+                "buttonDisconnected",
+                "buttonReady",
+            ]:
                 self._event_callback(button, event)
             elif button is not None:
                 self._event_callback(button, event)
@@ -298,13 +320,12 @@ class FlicHubTcpClient(asyncio.Protocol):
 
 class _JSONDecoder(json.JSONDecoder):
     def __init__(self, *args, **kwargs):
-        json.JSONDecoder.__init__(
-            self, object_hook=self.object_hook, *args, **kwargs)
+        json.JSONDecoder.__init__(self, object_hook=self.object_hook, *args, **kwargs)
 
     def object_hook(self, obj):
         ret = {}
         for key, value in obj.items():
-            if key in {'batteryTimestamp'}:
+            if key in {"batteryTimestamp"}:
                 ret[key] = datetime.fromtimestamp(value / 1000)
             else:
                 ret[key] = value

--- a/pyflichub/client.py
+++ b/pyflichub/client.py
@@ -297,6 +297,7 @@ class FlicHubTcpClient(asyncio.Protocol):
                 "buttonConnected",
                 "buttonDisconnected",
                 "buttonReady",
+                "irResult",
             ]:
                 self._event_callback(button, event)
             elif button is not None:

--- a/pyflichub/server_command.py
+++ b/pyflichub/server_command.py
@@ -6,3 +6,4 @@ class ServerCommand(StrEnum):
     SERVER_INFO = "server"
     HUB_INFO = "network"
     PLAY_IR = "play_ir"
+    PLAY_IR_RAW = "play_ir_raw"

--- a/tcpserver.js
+++ b/tcpserver.js
@@ -179,17 +179,22 @@ net.createServer(function (socket) {
                     if (parsed.command === "virtualDeviceUpdateState") {
                         flicapp.virtualDeviceUpdateState(parsed.dimmableType, parsed.virtualDeviceId, parsed.values);
                     }
+                    const irCallback = function(error) {
+                        if (error) {
+                            console.log("IR Play Error: " + error);
+                            write({'event': 'irResult', 'action': 'failed', 'meta_data': {'error': error.toString()}});
+                        } else {
+                            write({'event': 'irResult', 'action': 'success'});
+                        }
+                    };
+
                     if (parsed.command === "play_ir") {
-                        ir.play(parsed.signal_id);
+                        ir.play(parsed.signal_id, irCallback);
                     }
                     if (parsed.command === "play_ir_raw") {
                         if (parsed.arr && Array.isArray(parsed.arr)) {
                             var timings = new Uint32Array(parsed.arr);
-                            ir.play(timings, function(error) {
-                                if (error) {
-                                    console.log("IR Play Error: " + error);
-                                }
-                            });
+                            ir.play(timings, irCallback);
                         }
                     }
                 } catch (e) {

--- a/tcpserver.js
+++ b/tcpserver.js
@@ -182,6 +182,16 @@ net.createServer(function (socket) {
                     if (parsed.command === "play_ir") {
                         ir.play(parsed.signal_id);
                     }
+                    if (parsed.command === "play_ir_raw") {
+                        if (parsed.arr && Array.isArray(parsed.arr)) {
+                            var timings = new Uint32Array(parsed.arr);
+                            ir.play(timings, function(error) {
+                                if (error) {
+                                    console.log("IR Play Error: " + error);
+                                }
+                            });
+                        }
+                    }
                 } catch (e) {
                     console.error("Failed to parse JSON: " + msg);
                 }

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,7 +11,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 class DummyClient(FlicHubTcpClient):
     def __init__(self):
-        super().__init__('127.0.0.1', 8124, asyncio.new_event_loop())
+        super().__init__("127.0.0.1", 8124, asyncio.new_event_loop())
         self.events_received = []
         self.commands_received = []
 
@@ -28,11 +28,11 @@ def test_data_received_partial_data():
     assert len(client.events_received) == 0
     assert client._buffer == b'{"event": "button", "button": "aa:bb:cc", "action": "click"}'
 
-    client.data_received(b'\n')
+    client.data_received(b"\n")
     assert len(client.events_received) == 1
-    assert client.events_received[0].event == 'button'
-    assert client.events_received[0].button == 'aa:bb:cc'
-    assert client.events_received[0].action == 'click'
+    assert client.events_received[0].event == "button"
+    assert client.events_received[0].button == "aa:bb:cc"
+    assert client.events_received[0].action == "click"
     assert client.events_received[0].button_number is None
     assert client._buffer == b""
 
@@ -41,9 +41,9 @@ def test_data_received_button_number():
     client = DummyClient()
     client.data_received(b'{"event": "button", "button": "aa:bb:cc", "action": "single", "button_number": 0}\n')
     assert len(client.events_received) == 1
-    assert client.events_received[0].event == 'button'
-    assert client.events_received[0].button == 'aa:bb:cc'
-    assert client.events_received[0].action == 'single'
+    assert client.events_received[0].event == "button"
+    assert client.events_received[0].button == "aa:bb:cc"
+    assert client.events_received[0].action == "single"
     assert client.events_received[0].button_number == 0
     assert client._buffer == b""
 
@@ -55,17 +55,18 @@ def test_data_received_multiple_messages():
     )
     assert len(client.events_received) == 1
     assert len(client.commands_received) == 1
-    assert client.events_received[0].event == 'button'
-    assert client.commands_received[0].command == 'serverInfo'
+    assert client.events_received[0].event == "button"
+    assert client.commands_received[0].command == "serverInfo"
     assert client._buffer == b""
 
 
 def test_data_received_pong():
     client = DummyClient()
-    client.data_received(b'pong\n')
+    client.data_received(b"pong\n")
     assert len(client.events_received) == 0
     assert len(client.commands_received) == 0
     assert client._buffer == b""
+
 
 def test_button_events_handling():
     from pyflichub.button import FlicButton
@@ -75,21 +76,33 @@ def test_button_events_handling():
     def mock_event_callback(button, event):
         events_received.append((button, event))
 
-    client = FlicHubTcpClient('127.0.0.1', 8124, asyncio.new_event_loop(), event_callback=mock_event_callback)
+    client = FlicHubTcpClient("127.0.0.1", 8124, asyncio.new_event_loop(), event_callback=mock_event_callback)
 
     # Mock get_buttons so it doesn't try to send over TCP
     async def mock_get_buttons():
         return []
 
     def mock_create_task(coro):
-        coro.close() # prevent coroutine was never awaited warning
+        coro.close()  # prevent coroutine was never awaited warning
 
     client.get_buttons = mock_get_buttons
     client._loop.create_task = mock_create_task
 
-    btn1 = FlicButton(bdaddr="aa:bb:cc", serial_number="sn", color="black", name="test1",
-                      active_disconnect=False, connected=False, ready=False, battery_status=100,
-                      uuid="uuid", flic_version=2, firmware_version=1, key="key", passive_mode=False)
+    btn1 = FlicButton(
+        bdaddr="aa:bb:cc",
+        serial_number="sn",
+        color="black",
+        name="test1",
+        active_disconnect=False,
+        connected=False,
+        ready=False,
+        battery_status=100,
+        uuid="uuid",
+        flic_version=2,
+        firmware_version=1,
+        key="key",
+        passive_mode=False,
+    )
     client.buttons = [btn1]
 
     # Test buttonAdded
@@ -131,15 +144,29 @@ def test_virtual_device_update_event():
     def mock_event_callback(button, event):
         events_received.append((button, event))
 
-    client = FlicHubTcpClient('127.0.0.1', 8124, asyncio.new_event_loop(), event_callback=mock_event_callback)
+    client = FlicHubTcpClient("127.0.0.1", 8124, asyncio.new_event_loop(), event_callback=mock_event_callback)
 
-    btn1 = FlicButton(bdaddr="90:88:a9:5b:12:89", serial_number="sn", color="black", name="test_twist",
-                      active_disconnect=False, connected=True, ready=True, battery_status=100,
-                      uuid="uuid", flic_version=2, firmware_version=1, key="key", passive_mode=False)
+    btn1 = FlicButton(
+        bdaddr="90:88:a9:5b:12:89",
+        serial_number="sn",
+        color="black",
+        name="test_twist",
+        active_disconnect=False,
+        connected=True,
+        ready=True,
+        battery_status=100,
+        uuid="uuid",
+        flic_version=2,
+        firmware_version=1,
+        key="key",
+        passive_mode=False,
+    )
     client.buttons = [btn1]
 
     # Test virtualDeviceUpdate
-    client.data_received(b'{"event":"virtualDeviceUpdate","meta_data":{"button_id":"90:88:a9:5b:12:89","virtual_device_id":"Virtual Light","dimmable_type":"Light"},"values":{"brightness":0.823853}}\n')
+    client.data_received(
+        b'{"event":"virtualDeviceUpdate","meta_data":{"button_id":"90:88:a9:5b:12:89","virtual_device_id":"Virtual Light","dimmable_type":"Light"},"values":{"brightness":0.823853}}\n'
+    )
     assert len(events_received) == 1
     assert events_received[-1][0] == btn1
     assert events_received[-1][1].event == "virtualDeviceUpdate"
@@ -149,21 +176,33 @@ def test_virtual_device_update_event():
 
 def test_play_ir():
     from unittest.mock import MagicMock
+
     client = DummyClient()
     client._transport = MagicMock()
     client.play_ir("test_signal")
 
-    expected_payload = json.dumps({
-        "command": "play_ir",
-        "signal_id": "test_signal"
-    }) + "\n"
+    expected_payload = json.dumps({"command": "play_ir", "signal_id": "test_signal"}) + "\n"
+
+    client._transport.write.assert_called_once_with(expected_payload.encode())
+
+
+def test_play_ir_raw():
+    from unittest.mock import MagicMock
+
+    client = DummyClient()
+    client._transport = MagicMock()
+
+    test_arr = [38000, 9000, 4500, 560, 560]
+    client.play_ir_raw(test_arr)
+
+    expected_payload = json.dumps({"command": "play_ir_raw", "arr": test_arr}) + "\n"
 
     client._transport.write.assert_called_once_with(expected_payload.encode())
 
 
 def test_data_received_invalid_json():
     client = DummyClient()
-    client.data_received(b'invalid json\n')
+    client.data_received(b"invalid json\n")
     assert len(client.events_received) == 0
     assert len(client.commands_received) == 0
     assert client._buffer == b""


### PR DESCRIPTION
Updates the Flic Hub `tcpserver.js` and `pyflichub` client to support playing raw IR timings. This enables integrations like Home Assistant to send protocol-agnostic timing arrays instead of pre-recorded signal IDs.

### Changes
*   **`tcpserver.js`**: Added a `"play_ir_raw"` command handler that converts an incoming array of integers into a `Uint32Array` and passes it to `ir.play()`.
*   **`pyflichub/server_command.py`**: Added `PLAY_IR_RAW` to the `ServerCommand` enum.
*   **`pyflichub/client.py`**: Added `play_ir_raw(arr: list[int])` to `FlicHubTcpClient` to format and send the raw IR payload.
*   **Tests**: Added `test_play_ir_raw` in `tests/test_client.py` to ensure the correct payload is constructed and written to the transport.
*   **Documentation**: Updated `docs/events.md` to document the new `play_ir_raw` method.

---
*PR created automatically by Jules for task [6782762098000414676](https://jules.google.com/task/6782762098000414676) started by @JohNan*