### PR TITLE
Fix `buttonDown` and `buttonUp` native binding to enable accurate button hold duration and release tracking

### DIFF
--- a/tcpserver.js
+++ b/tcpserver.js
@@ -101,6 +101,7 @@ net.createServer(function (socket) {
     const buttonUpHandler = function (obj) {
         console.log('Button clicked:' + obj.bdaddr + ' - up')
         sendButtonPayload({ bdaddr: obj.bdaddr }, {action: 'up', button_number: obj.buttonNumber})
+        setTimeout(buttonIdle, 150, obj);
     };
 	
     const buttonIdle = function (obj) {
@@ -112,10 +113,7 @@ net.createServer(function (socket) {
         const action = obj.isSingleClick ? 'single' : obj.isDoubleClick ? 'double' : 'hold';
         console.log('Button clicked:' + obj.bdaddr + ' - ' + action)
 
-        buttonDownHandler(obj);
-        setTimeout(buttonUpHandler, 50, obj);
-        setTimeout(sendButtonPayload, 100, { bdaddr: obj.bdaddr }, {action, button_number: obj.buttonNumber});
-        setTimeout(buttonIdle, 150, obj);
+        sendButtonPayload({ bdaddr: obj.bdaddr }, {action, button_number: obj.buttonNumber});
     };
 
     const virtualDeviceUpdateHandler = function (metaData, values) {
@@ -142,6 +140,8 @@ net.createServer(function (socket) {
         write(payload);
     };
 
+    buttons.on('buttonDown', buttonDownHandler);
+    buttons.on('buttonUp', buttonUpHandler);
     buttons.on('buttonSingleOrDoubleClickOrHold', buttonSingleOrDoubleClickOrHoldHandler);
     buttons.on('buttonConnected', buttonConnectedHandler);
     buttons.on('buttonReady', buttonReadyHandler);
@@ -157,6 +157,8 @@ net.createServer(function (socket) {
     socket.on('end', function () {
         console.log('Client disconnected: ' + socket.remoteAddress);
 
+        buttons.removeListener('buttonDown', buttonDownHandler);
+        buttons.removeListener('buttonUp', buttonUpHandler);
         buttons.removeListener('buttonSingleOrDoubleClickOrHold', buttonSingleOrDoubleClickOrHoldHandler);
         buttons.removeListener('buttonConnected', buttonConnectedHandler);
         buttons.removeListener('buttonReady', buttonReadyHandler);


### PR DESCRIPTION
Previously, the `buttonDown` and `buttonUp` events were simulated to fire consecutively when `buttonSingleOrDoubleClickOrHold` was fired, entirely obfuscating the time elapsed between the button physical press and release. 

This PR alters `tcpserver.js` to instead bind directly to the native Flic Hub SDK `buttonDown` and `buttonUp` events so that `pyflichub-tcpclient` receivers are correctly notified exactly when physical interactions end, which allows reliable execution of 'release' actions after prolonged holds.

---
*PR created automatically by Jules for task [9922247163869710666](https://jules.google.com/task/9922247163869710666) started by @JohNan*