### PR TITLE
Bump version from 0.1.12 to 0.1.13

### DIFF
--- a/tcpserver.js
+++ b/tcpserver.js
@@ -6,7 +6,7 @@ const buttons = require('buttons');
 const flicapp = require('flicapp');
 const ir = require('ir');
 const EOL = "\n";
-const VERSION = "0.1.12";
+const VERSION = "0.1.13";
 
 // Configuration - start
 const HOST = "0.0.0.0";


### PR DESCRIPTION
This is causing a warning in Home Assistant. If this shouldn't be bumped, something the HA component code repo might should shift. 
This is likely what #24 is talking about (and implements what they did)